### PR TITLE
refactor(rest-api): enrich domain and introduce typed domain errors

### DIFF
--- a/apps/rest-api/src/application/usecases/auth/CreateUser.ts
+++ b/apps/rest-api/src/application/usecases/auth/CreateUser.ts
@@ -3,6 +3,7 @@ import { IUserRepository } from '@/application/repositories/IUserRepository';
 import { IPasswordHasher } from '@/application/services/IPasswordHasher';
 import { ITokenService } from '@/application/services/ITokenService';
 import { IUuidGenerator } from '@/application/services/IUuidGenerator';
+import { AlreadyExistsError } from '@/domain/errors/AlreadyExistsError';
 
 export class CreateUser {
   constructor(
@@ -17,7 +18,7 @@ export class CreateUser {
     const existsUser = await this.repository.findByEmail({ email: params.email });
 
     if (existsUser) {
-      throw new Error('Email already exists');
+      throw new AlreadyExistsError('Email already exists');
     }
 
     const hashedPassword = await this.passwordHasher.hash(params.password);

--- a/apps/rest-api/src/application/usecases/auth/GetAuthMe.ts
+++ b/apps/rest-api/src/application/usecases/auth/GetAuthMe.ts
@@ -1,4 +1,5 @@
 import { IUserRepository } from '@/application/repositories/IUserRepository';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
 
 export class GetAuthMe {
   constructor(private repository: IUserRepository) {}
@@ -6,7 +7,7 @@ export class GetAuthMe {
   async execute(params: { userId: number }) {
     const user = await this.repository.findById({ id: params.userId });
     if (!user) {
-      throw new Error('Email not found');
+      throw new NotFoundError('User not found');
     }
 
     return {

--- a/apps/rest-api/src/application/usecases/auth/RefreshToken.ts
+++ b/apps/rest-api/src/application/usecases/auth/RefreshToken.ts
@@ -2,6 +2,7 @@ import { IRefreshTokenRepository } from '@/application/repositories/IRefreshToke
 import { IUserRepository } from '@/application/repositories/IUserRepository';
 import { ITokenService } from '@/application/services/ITokenService';
 import { IUuidGenerator } from '@/application/services/IUuidGenerator';
+import { UnauthorizedError } from '@/domain/errors/UnauthorizedError';
 
 export class RefreshToken {
   constructor(
@@ -18,12 +19,12 @@ export class RefreshToken {
     });
 
     if (!savedRefreshToken || savedRefreshToken.revoked) {
-      throw new Error('Unauthorized');
+      throw new UnauthorizedError('Unauthorized');
     }
 
     const hashedToken = this.tokenService.hashRefreshToken(params.refreshToken);
     if (hashedToken !== savedRefreshToken.hashedToken) {
-      throw new Error('Unauthorized');
+      throw new UnauthorizedError('Unauthorized');
     }
 
     const user = await this.repository.findById({
@@ -31,7 +32,7 @@ export class RefreshToken {
     });
 
     if (!user) {
-      throw new Error('Unauthorized');
+      throw new UnauthorizedError('Unauthorized');
     }
 
     await this.refreshTokenRepository.delete({

--- a/apps/rest-api/src/application/usecases/auth/SignIn.ts
+++ b/apps/rest-api/src/application/usecases/auth/SignIn.ts
@@ -3,6 +3,7 @@ import { IUserRepository } from '@/application/repositories/IUserRepository';
 import { IPasswordHasher } from '@/application/services/IPasswordHasher';
 import { ITokenService } from '@/application/services/ITokenService';
 import { IUuidGenerator } from '@/application/services/IUuidGenerator';
+import { InvalidCredentialError } from '@/domain/errors/InvalidCredentialError';
 
 export class SignIn {
   constructor(
@@ -16,7 +17,7 @@ export class SignIn {
   async execute(params: { email: string; password: string }) {
     const existsUser = await this.repository.findByEmail({ email: params.email });
     if (!existsUser) {
-      throw new Error('Email not found');
+      throw new InvalidCredentialError('Invalid email or password');
     }
 
     const validPassword = await this.passwordHasher.compare(
@@ -24,7 +25,7 @@ export class SignIn {
       existsUser.hashedPassword,
     );
     if (!validPassword) {
-      throw new Error('Password is invalid');
+      throw new InvalidCredentialError('Invalid email or password');
     }
 
     const uuid = this.uuidGenerator.generate();

--- a/apps/rest-api/src/application/usecases/task/CreateTask.ts
+++ b/apps/rest-api/src/application/usecases/task/CreateTask.ts
@@ -4,20 +4,26 @@ import { TaskModel } from '@/domain/models/TaskModel';
 export class CreateTask {
   constructor(private repository: ITaskRepository) {}
 
-  async execute(params: Omit<TaskModel, 'id' | 'done' | 'sort'> & { userId: number }) {
+  async execute(params: {
+    userId: number;
+    taskGroupId: number;
+    title: string;
+    description?: string;
+    dueDate?: string;
+    dueTime?: string;
+  }) {
     const maxSort = await this.repository.findMaxSort({
       taskGroupId: params.taskGroupId,
       userId: params.userId,
     });
 
-    const model = new TaskModel({
-      id: 0,
+    const model = TaskModel.createNew({
       taskGroupId: params.taskGroupId,
       title: params.title,
+      description: params.description,
       dueDate: params.dueDate,
       dueTime: params.dueTime,
-      description: params.description,
-      sort: Math.floor(maxSort) + TaskModel.INITIAL_SORT_VALUE,
+      maxSort,
     });
     return await this.repository.save({ item: model });
   }

--- a/apps/rest-api/src/application/usecases/task/DeleteTask.ts
+++ b/apps/rest-api/src/application/usecases/task/DeleteTask.ts
@@ -1,4 +1,5 @@
 import { ITaskRepository } from '@/application/repositories/ITaskRepository';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
 
 export class DeleteTask {
   constructor(private repository: ITaskRepository) {}
@@ -9,7 +10,7 @@ export class DeleteTask {
       userId: params.userId,
     });
     if (!model) {
-      throw new Error('Task not found');
+      throw new NotFoundError('Task not found');
     }
     return await this.repository.delete({ item: model });
   }

--- a/apps/rest-api/src/application/usecases/task/UpdateTask.ts
+++ b/apps/rest-api/src/application/usecases/task/UpdateTask.ts
@@ -1,4 +1,5 @@
 import { ITaskRepository } from '@/application/repositories/ITaskRepository';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
 
 export class UpdateTask {
   constructor(private repository: ITaskRepository) {}
@@ -18,11 +19,18 @@ export class UpdateTask {
       userId: params.userId,
     });
     if (!model) {
-      throw new Error('Task not found');
+      throw new NotFoundError('Task not found');
     }
 
-    Object.assign(model, params);
+    const updated = model.withUpdates({
+      title: params.title,
+      description: params.description,
+      dueDate: params.dueDate,
+      dueTime: params.dueTime,
+      done: params.done,
+      sort: params.sort,
+    });
 
-    return await this.repository.save({ item: model });
+    return await this.repository.save({ item: updated });
   }
 }

--- a/apps/rest-api/src/application/usecases/task/UpdateTaskSort.ts
+++ b/apps/rest-api/src/application/usecases/task/UpdateTaskSort.ts
@@ -1,4 +1,5 @@
 import { ITaskRepository } from '@/application/repositories/ITaskRepository';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
 import { TaskModel } from '@/domain/models/TaskModel';
 
 export class UpdateTaskSort {
@@ -15,37 +16,37 @@ export class UpdateTaskSort {
       userId: params.userId,
     });
     if (!model) {
-      throw new Error('Task not found');
+      throw new NotFoundError('Task not found');
     }
 
-    let prevModelSort = 0;
+    let prevSort: number | null = null;
     if (params.prevId) {
       const prevModel = await this.repository.findOne({
         id: params.prevId,
         userId: params.userId,
       });
       if (!prevModel) {
-        throw new Error('Task not found');
+        throw new NotFoundError('Task not found');
       }
-      prevModelSort = prevModel.sort;
+      prevSort = prevModel.sort;
     }
 
-    let nextModelSort = TaskModel.INITIAL_SORT_VALUE;
+    let nextSort: number | null = null;
     if (params.nextId) {
       const nextModel = await this.repository.findOne({
         id: params.nextId,
         userId: params.userId,
       });
       if (!nextModel) {
-        throw new Error('Task not found');
+        throw new NotFoundError('Task not found');
       }
-      nextModelSort = nextModel.sort;
+      nextSort = nextModel.sort;
     }
 
-    Object.assign(model, {
-      sort: (prevModelSort + nextModelSort) / 2,
+    const updated = model.withUpdates({
+      sort: TaskModel.sortBetween(prevSort, nextSort),
     });
 
-    return await this.repository.save({ item: model });
+    return await this.repository.save({ item: updated });
   }
 }

--- a/apps/rest-api/src/application/usecases/taskGroup/CreateTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/CreateTaskGroup.ts
@@ -4,16 +4,13 @@ import { TaskGroupModel } from '@/domain/models/TaskGroupModel';
 export class CreateTaskGroup {
   constructor(private repository: ITaskGroupRepository) {}
 
-  private INITIAL_SORT_VALUE = 65535;
-
-  async execute(params: Omit<TaskGroupModel, 'id' | 'sort'>) {
+  async execute(params: { userId: number; name: string }) {
     const maxSort = await this.repository.findMaxSort({ userId: params.userId });
 
-    const model = new TaskGroupModel({
-      id: 0,
-      name: params.name,
+    const model = TaskGroupModel.createNew({
       userId: params.userId,
-      sort: Math.floor(maxSort) + this.INITIAL_SORT_VALUE,
+      name: params.name,
+      maxSort,
     });
     return await this.repository.save({ item: model });
   }

--- a/apps/rest-api/src/application/usecases/taskGroup/DeleteTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/DeleteTaskGroup.ts
@@ -1,4 +1,5 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
 
 export class DeleteTaskGroup {
   constructor(private repository: ITaskGroupRepository) {}
@@ -9,7 +10,7 @@ export class DeleteTaskGroup {
       userId: params.userId,
     });
     if (!model) {
-      throw new Error('TaskGroup not found');
+      throw new NotFoundError('TaskGroup not found');
     }
     return await this.repository.delete({ item: model });
   }

--- a/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroup.ts
@@ -1,4 +1,5 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
 
 export class UpdateTaskGroup {
   constructor(private repository: ITaskGroupRepository) {}
@@ -14,11 +15,14 @@ export class UpdateTaskGroup {
       userId: params.userId,
     });
     if (!model) {
-      throw new Error('TaskGroup not found');
+      throw new NotFoundError('TaskGroup not found');
     }
 
-    Object.assign(model, params);
+    const updated = model.withUpdates({
+      name: params.name,
+      sort: params.sort,
+    });
 
-    return await this.repository.save({ item: model });
+    return await this.repository.save({ item: updated });
   }
 }

--- a/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroupSort.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroupSort.ts
@@ -1,4 +1,5 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
 import { TaskGroupModel } from '@/domain/models/TaskGroupModel';
 
 export class UpdateTaskGroupSort {
@@ -15,37 +16,37 @@ export class UpdateTaskGroupSort {
       userId: params.userId,
     });
     if (!model) {
-      throw new Error('Task Group not found');
+      throw new NotFoundError('TaskGroup not found');
     }
 
-    let prevModelSort = 0;
+    let prevSort: number | null = null;
     if (params.prevId) {
       const prevModel = await this.repository.findOne({
         id: params.prevId,
         userId: params.userId,
       });
       if (!prevModel) {
-        throw new Error('Task Group not found');
+        throw new NotFoundError('TaskGroup not found');
       }
-      prevModelSort = prevModel.sort;
+      prevSort = prevModel.sort;
     }
 
-    let nextModelSort = TaskGroupModel.INITIAL_SORT_VALUE;
+    let nextSort: number | null = null;
     if (params.nextId) {
       const nextModel = await this.repository.findOne({
         id: params.nextId,
         userId: params.userId,
       });
       if (!nextModel) {
-        throw new Error('Task Group not found');
+        throw new NotFoundError('TaskGroup not found');
       }
-      nextModelSort = nextModel.sort;
+      nextSort = nextModel.sort;
     }
 
-    Object.assign(model, {
-      sort: (prevModelSort + nextModelSort) / 2,
+    const updated = model.withUpdates({
+      sort: TaskGroupModel.sortBetween(prevSort, nextSort),
     });
 
-    return await this.repository.save({ item: model });
+    return await this.repository.save({ item: updated });
   }
 }

--- a/apps/rest-api/src/domain/errors/AlreadyExistsError.ts
+++ b/apps/rest-api/src/domain/errors/AlreadyExistsError.ts
@@ -1,0 +1,3 @@
+import { DomainError } from './DomainError';
+
+export class AlreadyExistsError extends DomainError {}

--- a/apps/rest-api/src/domain/errors/DomainError.ts
+++ b/apps/rest-api/src/domain/errors/DomainError.ts
@@ -1,0 +1,6 @@
+export abstract class DomainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/apps/rest-api/src/domain/errors/InvalidCredentialError.ts
+++ b/apps/rest-api/src/domain/errors/InvalidCredentialError.ts
@@ -1,0 +1,3 @@
+import { DomainError } from './DomainError';
+
+export class InvalidCredentialError extends DomainError {}

--- a/apps/rest-api/src/domain/errors/NotFoundError.ts
+++ b/apps/rest-api/src/domain/errors/NotFoundError.ts
@@ -1,0 +1,3 @@
+import { DomainError } from './DomainError';
+
+export class NotFoundError extends DomainError {}

--- a/apps/rest-api/src/domain/errors/UnauthorizedError.ts
+++ b/apps/rest-api/src/domain/errors/UnauthorizedError.ts
@@ -1,0 +1,3 @@
+import { DomainError } from './DomainError';
+
+export class UnauthorizedError extends DomainError {}

--- a/apps/rest-api/src/domain/models/TaskGroupModel.ts
+++ b/apps/rest-api/src/domain/models/TaskGroupModel.ts
@@ -22,4 +22,38 @@ export class TaskGroupModel extends BaseModel {
     this.sort = props.sort;
     this.tasks = props.tasks;
   }
+
+  static createNew(props: {
+    userId: number;
+    name: string;
+    maxSort: number;
+  }): TaskGroupModel {
+    return new TaskGroupModel({
+      id: 0,
+      userId: props.userId,
+      name: props.name,
+      sort: Math.floor(props.maxSort) + TaskGroupModel.INITIAL_SORT_VALUE,
+    });
+  }
+
+  static sortBetween(prev: number | null, next: number | null): number {
+    const prevSort = prev ?? 0;
+    const nextSort = next ?? TaskGroupModel.INITIAL_SORT_VALUE;
+    return (prevSort + nextSort) / 2;
+  }
+
+  withUpdates(
+    updates: Partial<{
+      name: string;
+      sort: number;
+    }>,
+  ): TaskGroupModel {
+    return new TaskGroupModel({
+      id: this.id,
+      userId: this.userId,
+      name: updates.name ?? this.name,
+      sort: updates.sort ?? this.sort,
+      tasks: this.tasks,
+    });
+  }
 }

--- a/apps/rest-api/src/domain/models/TaskModel.ts
+++ b/apps/rest-api/src/domain/models/TaskModel.ts
@@ -30,4 +30,51 @@ export class TaskModel extends BaseModel {
     this.dueTime = props.dueTime;
     this.sort = props.sort;
   }
+
+  static createNew(props: {
+    taskGroupId: number;
+    title: string;
+    description?: string;
+    dueDate?: string;
+    dueTime?: string;
+    maxSort: number;
+  }): TaskModel {
+    return new TaskModel({
+      id: 0,
+      taskGroupId: props.taskGroupId,
+      title: props.title,
+      description: props.description,
+      dueDate: props.dueDate,
+      dueTime: props.dueTime,
+      sort: Math.floor(props.maxSort) + TaskModel.INITIAL_SORT_VALUE,
+    });
+  }
+
+  static sortBetween(prev: number | null, next: number | null): number {
+    const prevSort = prev ?? 0;
+    const nextSort = next ?? TaskModel.INITIAL_SORT_VALUE;
+    return (prevSort + nextSort) / 2;
+  }
+
+  withUpdates(
+    updates: Partial<{
+      title: string;
+      description: string;
+      dueDate: string;
+      dueTime: string;
+      done: boolean;
+      sort: number;
+    }>,
+  ): TaskModel {
+    return new TaskModel({
+      id: this.id,
+      taskGroupId: this.taskGroupId,
+      title: updates.title ?? this.title,
+      description: updates.description ?? this.description,
+      dueDate: updates.dueDate ?? this.dueDate,
+      dueTime: updates.dueTime ?? this.dueTime,
+      done: updates.done ?? this.done,
+      sort: updates.sort ?? this.sort,
+    });
+  }
 }

--- a/apps/rest-api/src/interfaces/http/app.ts
+++ b/apps/rest-api/src/interfaces/http/app.ts
@@ -1,8 +1,18 @@
+import { AlreadyExistsError } from '@/domain/errors/AlreadyExistsError';
+import { InvalidCredentialError } from '@/domain/errors/InvalidCredentialError';
+import { NotFoundError } from '@/domain/errors/NotFoundError';
+import { UnauthorizedError } from '@/domain/errors/UnauthorizedError';
 import { AppDeps } from '@/interfaces/deps';
 import { createAuthRoute } from '@/interfaces/http/routes/auth';
 import { createTaskGroupsRoute } from '@/interfaces/http/routes/taskGroups';
 import { createTasksRoute } from '@/interfaces/http/routes/tasks';
-import { errorResponse, successResponse } from '@/interfaces/http/utils/responses';
+import {
+  conflictResponse,
+  errorResponse,
+  notFoundResponse,
+  successResponse,
+  unauthorizedResponse,
+} from '@/interfaces/http/utils/responses';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
@@ -34,6 +44,15 @@ export const createApp = (deps: AppDeps) => {
 
   // エラーハンドリング
   app.onError((err, _c) => {
+    if (err instanceof NotFoundError) {
+      return notFoundResponse(err.message);
+    }
+    if (err instanceof UnauthorizedError || err instanceof InvalidCredentialError) {
+      return unauthorizedResponse(err.message);
+    }
+    if (err instanceof AlreadyExistsError) {
+      return conflictResponse(err.message);
+    }
     console.error(err);
     return errorResponse();
   });

--- a/apps/rest-api/src/interfaces/http/utils/responses.ts
+++ b/apps/rest-api/src/interfaces/http/utils/responses.ts
@@ -41,6 +41,20 @@ export const notFoundResponse = (message = 'Not Found') => {
 };
 
 /**
+ * Create a 409 response object
+ * @param message string
+ * @returns Response
+ */
+export const conflictResponse = (message = 'Conflict') => {
+  return new Response(JSON.stringify([message]), {
+    status: 409,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+
+/**
  * Create a 422 response object
  * @param messages string[]
  * @returns Response


### PR DESCRIPTION
> Stacked on #2. Merge #2 first, then this PR's base will need to be retargeted to \`main\`.

## Summary
- **Phase 3-1**: \`TaskModel\` / \`TaskGroupModel\` に \`createNew\` / \`withUpdates\` / \`sortBetween\` を導入。UseCase の \`Object.assign(model, params)\` を全廃し、ドメインの不変性を取り戻す。ソート計算もドメインに集約。
- **Phase 3-2**: \`DomainError\` 基底 + \`NotFoundError\` / \`AlreadyExistsError\` / \`InvalidCredentialError\` / \`UnauthorizedError\` を追加。UseCase の \`throw new Error('...')\` を型付き例外に置き換え、\`app.onError\` で 401 / 404 / 409 にマッピング（旧実装は全部 500 に潰していた）。\`SignIn\` は \`Email not found\` と \`Password is invalid\` を単一の \`InvalidCredentialError\` に統合（ユーザー列挙対策）。
- **Phase 3-5**: \`CreateTaskGroup\` の \`private INITIAL_SORT_VALUE = 65535\` を撤廃し、\`TaskGroupModel.createNew\` に集約（DRY）。

## Bug fixes (副次効果)
- \`UpdateTask\` / \`UpdateTaskGroup\` の \`Object.assign(model, params)\` は **未指定フィールドも \`undefined\` で上書き** していたため、PATCH 半更新で意図せず \`null\` 化する潜在バグを抱えていた。\`withUpdates\` の \`?? this.field\` で正しく既存値を維持するようにした。
- \`Task\` / \`TaskGroup\` の \`readonly\` 宣言が \`Object.assign\` で踏みにじられていた問題を解消。

## Out of scope (Phase 3 残)
- **Phase 3-3**: Unit of Work / トランザクション境界（\`CreateUser\` のユーザー作成 + リフレッシュトークン作成、\`TaskGroup\` 削除時のカスケード等）
- \`package.json:2\` の名称統一（影響範囲が pnpm filter / turbo に及ぶため別 PR）
- \`uuid\` パッケージの ESM \`require\` 残置（軽微）

## Test plan
- [ ] \`pnpm @rest test\` で \`SignIn.test.ts\` がパス
- [ ] \`pnpm @rest dev\` で起動できる
- [ ] サインアップで重複メール → 409 になる（旧: 500）
- [ ] サインインで誤パスワード → 401 + \"Invalid email or password\"（旧: 500）
- [ ] 存在しない \`/tasks/:taskId\` PATCH → 404（旧: 500）
- [ ] タスクの PATCH で \`title\` のみ送って既存の \`description\` が保たれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)