### PR TITLE
refactor(rest-api): Unit of Work でトランザクション境界を導入

### DIFF
--- a/apps/rest-api/src/application/services/IUnitOfWork.ts
+++ b/apps/rest-api/src/application/services/IUnitOfWork.ts
@@ -2,18 +2,14 @@ import { IRefreshTokenRepository } from '@/application/repositories/IRefreshToke
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
 import { ITaskRepository } from '@/application/repositories/ITaskRepository';
 import { IUserRepository } from '@/application/repositories/IUserRepository';
-import { IPasswordHasher } from '@/application/services/IPasswordHasher';
-import { ITokenService } from '@/application/services/ITokenService';
-import { IUnitOfWork } from '@/application/services/IUnitOfWork';
-import { IUuidGenerator } from '@/application/services/IUuidGenerator';
 
-export interface AppDeps {
+export interface TransactionalRepositories {
   userRepository: IUserRepository;
   refreshTokenRepository: IRefreshTokenRepository;
   taskRepository: ITaskRepository;
   taskGroupRepository: ITaskGroupRepository;
-  passwordHasher: IPasswordHasher;
-  tokenService: ITokenService;
-  uuidGenerator: IUuidGenerator;
-  unitOfWork: IUnitOfWork;
+}
+
+export interface IUnitOfWork {
+  transaction<T>(work: (repos: TransactionalRepositories) => Promise<T>): Promise<T>;
 }

--- a/apps/rest-api/src/application/usecases/auth/CreateUser.ts
+++ b/apps/rest-api/src/application/usecases/auth/CreateUser.ts
@@ -1,47 +1,47 @@
-import { IRefreshTokenRepository } from '@/application/repositories/IRefreshTokenRepository';
-import { IUserRepository } from '@/application/repositories/IUserRepository';
 import { IPasswordHasher } from '@/application/services/IPasswordHasher';
 import { ITokenService } from '@/application/services/ITokenService';
+import { IUnitOfWork } from '@/application/services/IUnitOfWork';
 import { IUuidGenerator } from '@/application/services/IUuidGenerator';
 import { AlreadyExistsError } from '@/domain/errors/AlreadyExistsError';
 
 export class CreateUser {
   constructor(
-    private repository: IUserRepository,
-    private refreshTokenRepository: IRefreshTokenRepository,
+    private unitOfWork: IUnitOfWork,
     private passwordHasher: IPasswordHasher,
     private tokenService: ITokenService,
     private uuidGenerator: IUuidGenerator,
   ) {}
 
   async execute(params: { email: string; password: string; name: string }) {
-    const existsUser = await this.repository.findByEmail({ email: params.email });
-
-    if (existsUser) {
-      throw new AlreadyExistsError('Email already exists');
-    }
-
+    // bcrypt はトランザクション外で実行（DB コネクションを長時間保持しないため）
     const hashedPassword = await this.passwordHasher.hash(params.password);
-
-    const user = await this.repository.create({
-      name: params.name,
-      email: params.email,
-      hashedPassword: hashedPassword,
-    });
-
     const uuid = this.uuidGenerator.generate();
-    const { accessToken, refreshToken } = this.tokenService.generateTokens(user.id, uuid);
-    const hashedToken = this.tokenService.hashRefreshToken(refreshToken);
 
-    await this.refreshTokenRepository.create({
-      uuid: uuid,
-      hashedToken: hashedToken,
-      userId: user.id,
+    return this.unitOfWork.transaction(async (repos) => {
+      const existsUser = await repos.userRepository.findByEmail({ email: params.email });
+      if (existsUser) {
+        throw new AlreadyExistsError('Email already exists');
+      }
+
+      const user = await repos.userRepository.create({
+        name: params.name,
+        email: params.email,
+        hashedPassword: hashedPassword,
+      });
+
+      const { accessToken, refreshToken } = this.tokenService.generateTokens(user.id, uuid);
+      const hashedToken = this.tokenService.hashRefreshToken(refreshToken);
+
+      await repos.refreshTokenRepository.create({
+        uuid: uuid,
+        hashedToken: hashedToken,
+        userId: user.id,
+      });
+
+      return {
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+      };
     });
-
-    return {
-      accessToken: accessToken,
-      refreshToken: refreshToken,
-    };
   }
 }

--- a/apps/rest-api/src/application/usecases/taskGroup/DeleteTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/DeleteTaskGroup.ts
@@ -1,17 +1,19 @@
-import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
+import { IUnitOfWork } from '@/application/services/IUnitOfWork';
 import { NotFoundError } from '@/domain/errors/NotFoundError';
 
 export class DeleteTaskGroup {
-  constructor(private repository: ITaskGroupRepository) {}
+  constructor(private unitOfWork: IUnitOfWork) {}
 
   async execute(params: { userId: number; taskGroupId: number }) {
-    const model = await this.repository.findOne({
-      id: params.taskGroupId,
-      userId: params.userId,
+    return this.unitOfWork.transaction(async (repos) => {
+      const model = await repos.taskGroupRepository.findOne({
+        id: params.taskGroupId,
+        userId: params.userId,
+      });
+      if (!model) {
+        throw new NotFoundError('TaskGroup not found');
+      }
+      return repos.taskGroupRepository.delete({ item: model });
     });
-    if (!model) {
-      throw new NotFoundError('TaskGroup not found');
-    }
-    return await this.repository.delete({ item: model });
   }
 }

--- a/apps/rest-api/src/index.ts
+++ b/apps/rest-api/src/index.ts
@@ -2,6 +2,7 @@ import { BcryptPasswordHasher } from '@/infrastructure/auth/BcryptPasswordHasher
 import { JwtTokenService } from '@/infrastructure/auth/JwtTokenService';
 import { UuidGenerator } from '@/infrastructure/auth/UuidGenerator';
 import { db } from '@/infrastructure/database/db';
+import { PrismaUnitOfWork } from '@/infrastructure/database/PrismaUnitOfWork';
 import { RefreshTokenRepository } from '@/infrastructure/repository/RefreshTokenRepository';
 import { TaskGroupRepository } from '@/infrastructure/repository/TaskGroupRepository';
 import { TaskRepository } from '@/infrastructure/repository/TaskRepository';
@@ -29,6 +30,7 @@ const deps: AppDeps = {
   passwordHasher: new BcryptPasswordHasher(),
   tokenService: new JwtTokenService({ accessSecret, refreshSecret }),
   uuidGenerator: new UuidGenerator(),
+  unitOfWork: new PrismaUnitOfWork(db),
 };
 
 const app = createApp(deps);

--- a/apps/rest-api/src/infrastructure/database/PrismaUnitOfWork.ts
+++ b/apps/rest-api/src/infrastructure/database/PrismaUnitOfWork.ts
@@ -1,0 +1,21 @@
+import { IUnitOfWork, TransactionalRepositories } from '@/application/services/IUnitOfWork';
+import { RefreshTokenRepository } from '@/infrastructure/repository/RefreshTokenRepository';
+import { TaskGroupRepository } from '@/infrastructure/repository/TaskGroupRepository';
+import { TaskRepository } from '@/infrastructure/repository/TaskRepository';
+import { UserRepository } from '@/infrastructure/repository/UserRepository';
+import { PrismaClient } from '@prisma/client';
+
+export class PrismaUnitOfWork implements IUnitOfWork {
+  constructor(private db: PrismaClient) {}
+
+  async transaction<T>(work: (repos: TransactionalRepositories) => Promise<T>): Promise<T> {
+    return this.db.$transaction(async (tx) => {
+      return work({
+        userRepository: new UserRepository(tx),
+        refreshTokenRepository: new RefreshTokenRepository(tx),
+        taskRepository: new TaskRepository(tx),
+        taskGroupRepository: new TaskGroupRepository(tx),
+      });
+    });
+  }
+}

--- a/apps/rest-api/src/infrastructure/repository/RefreshTokenRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/RefreshTokenRepository.ts
@@ -1,9 +1,9 @@
 import { IRefreshTokenRepository } from '@/application/repositories/IRefreshTokenRepository';
 import { RefreshTokenModel } from '@/domain/models/RefreshTokenModel';
-import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 export class RefreshTokenRepository implements IRefreshTokenRepository {
-  constructor(private db: PrismaClient) {}
+  constructor(private db: Prisma.TransactionClient) {}
 
   async create(params: {
     uuid: string;

--- a/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
@@ -1,10 +1,10 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
 import { TaskGroupModel } from '@/domain/models/TaskGroupModel';
 import { TaskModel } from '@/domain/models/TaskModel';
-import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 export class TaskGroupRepository implements ITaskGroupRepository {
-  constructor(private db: PrismaClient) {}
+  constructor(private db: Prisma.TransactionClient) {}
 
   async findAll(params: { userId: number }): Promise<TaskGroupModel[]> {
     const list = await this.db.taskGroup.findMany({

--- a/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
@@ -1,9 +1,9 @@
 import { ITaskRepository } from '@/application/repositories/ITaskRepository';
 import { TaskModel } from '@/domain/models/TaskModel';
-import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 export class TaskRepository implements ITaskRepository {
-  constructor(private db: PrismaClient) {}
+  constructor(private db: Prisma.TransactionClient) {}
 
   async findOne(params: { id: number; userId: number }): Promise<TaskModel | null> {
     const item = await this.db.task.findFirst({

--- a/apps/rest-api/src/infrastructure/repository/UserRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/UserRepository.ts
@@ -1,9 +1,9 @@
 import { IUserRepository } from '@/application/repositories/IUserRepository';
 import { UserModel } from '@/domain/models/UserModel';
-import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 export class UserRepository implements IUserRepository {
-  constructor(private db: PrismaClient) {}
+  constructor(private db: Prisma.TransactionClient) {}
 
   async findByEmail(params: { email: string }): Promise<UserModel | null> {
     const item = await this.db.user.findUnique({

--- a/apps/rest-api/src/interfaces/controllers/AuthController.ts
+++ b/apps/rest-api/src/interfaces/controllers/AuthController.ts
@@ -14,8 +14,7 @@ export class AuthController {
     name: string;
   }) {
     const usecase = new CreateUser(
-      this.deps.userRepository,
-      this.deps.refreshTokenRepository,
+      this.deps.unitOfWork,
       this.deps.passwordHasher,
       this.deps.tokenService,
       this.deps.uuidGenerator,

--- a/apps/rest-api/src/interfaces/controllers/TaskGroupController.ts
+++ b/apps/rest-api/src/interfaces/controllers/TaskGroupController.ts
@@ -63,7 +63,7 @@ export class TaskGroupController {
     id: number;
     userId: number;
   }) {
-    const usecase = new DeleteTaskGroup(this.deps.taskGroupRepository);
+    const usecase = new DeleteTaskGroup(this.deps.unitOfWork);
     const res = await usecase.execute({
       taskGroupId: params.id,
       userId: params.userId,


### PR DESCRIPTION
## Summary

Phase 3-3: アプリケーション層に `IUnitOfWork` 抽象を導入し、`CreateUser` と `DeleteTaskGroup` のマルチステップ書き込みを 1 トランザクションに括る。

- **`application/services/IUnitOfWork.ts`** — `transaction(work)` で tx スコープのリポジトリ集合 (`TransactionalRepositories`) をコールバックに渡すインターフェース。
- **`infrastructure/database/PrismaUnitOfWork.ts`** — Prisma の `$transaction` 内で各 Repository を `tx` でリビルドする実装。
- **Repository 群** — `PrismaClient` ではなく `Prisma.TransactionClient` を受け取るように型変更（`PrismaClient` も同シェイプなので Composition Root 側はそのまま渡せる）。

### トランザクション化対象

- **`CreateUser`** — `user.create` + `refreshToken.create` を 1 tx にまとめ、片方が失敗したら両方ロールバック。`bcrypt.hash` は CPU 負荷が高いため tx 外で実行（コネクション保持時間を最小化）。
- **`DeleteTaskGroup`** — `findOne` チェックと `taskGroupRepository.delete`（内部で子 Task 群を `deleteMany` してから親を `delete`）を 1 tx にまとめる。FK 制約による中途半端な状態を回避。

## Stacked PR

- ベース: \`refactor/onion-phase3\` (#3)
- PR #3 が main にマージされた後、本 PR のベースを \`main\` に付け替える運用を想定。

## Out of scope

- リポジトリの集約境界整理（`TaskGroupRepository.delete` が `db.task` を直接触る点等）
- テスト追加（`CreateUser` の tx ロールバック挙動の統合テスト）
- 他の複数書き込みユースケースへの UoW 展開（現時点では該当なし）

## Test plan

- [ ] `pnpm install` 後 `pnpm --filter @ts-layered-architecture/rest-api exec tsc --noEmit` が通る
- [ ] `pnpm --filter @ts-layered-architecture/rest-api test` が通る（既存 SignIn テスト）
- [ ] 手動: signUp が成功 → user と refresh_token が両方作成されている
- [ ] 手動: 任意のタイミングで refreshToken.create を失敗させ、user も作成されないことを確認
- [ ] 手動: TaskGroup 削除で配下の Task も同時に削除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)