### PR TITLE
refactor(rest-api): TaskGroupRepository から集約越境を除去

### DIFF
--- a/apps/rest-api/src/application/repositories/ITaskRepository.ts
+++ b/apps/rest-api/src/application/repositories/ITaskRepository.ts
@@ -6,4 +6,5 @@ export interface ITaskRepository {
   save(params: { item: TaskModel }): Promise<TaskModel>;
   delete(params: { item: TaskModel }): Promise<number>;
   deleteDone(params: { userId: number; taskGroupId?: number }): Promise<number>;
+  deleteByTaskGroupId(params: { taskGroupId: number }): Promise<number>;
 }

--- a/apps/rest-api/src/application/usecases/taskGroup/DeleteTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/DeleteTaskGroup.ts
@@ -13,6 +13,8 @@ export class DeleteTaskGroup {
       if (!model) {
         throw new NotFoundError('TaskGroup not found');
       }
+      // 外部キー制約のため、先に配下の Task を削除する
+      await repos.taskRepository.deleteByTaskGroupId({ taskGroupId: model.id });
       return repos.taskGroupRepository.delete({ item: model });
     });
   }

--- a/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
@@ -116,13 +116,6 @@ export class TaskGroupRepository implements ITaskGroupRepository {
   }
 
   async delete(params: { item: TaskGroupModel }): Promise<number> {
-    // 外部キー制約のため、先にタスクを削除する
-    await this.db.task.deleteMany({
-      where: {
-        taskGroupId: params.item.id,
-      },
-    });
-
     const item = await this.db.taskGroup.delete({
       where: {
         id: params.item.id,

--- a/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
@@ -99,4 +99,14 @@ export class TaskRepository implements ITaskRepository {
 
     return res.count;
   }
+
+  async deleteByTaskGroupId(params: { taskGroupId: number }): Promise<number> {
+    const res = await this.db.task.deleteMany({
+      where: {
+        taskGroupId: params.taskGroupId,
+      },
+    });
+
+    return res.count;
+  }
 }


### PR DESCRIPTION
## Summary

Phase 4: `TaskGroupRepository.delete` が `db.task.deleteMany` を直接呼んでいた集約境界の越境を解消する。Task を独立した集約として扱い、削除カスケードを `DeleteTaskGroup` usecase に移動した。

## 変更点

- **`ITaskRepository.deleteByTaskGroupId`** を追加（Task 集約をまとめて削除）。
- **`TaskGroupRepository.delete`** から `db.task.deleteMany` を除去。`taskGroup.delete` のみを行う純粋な集約操作に。
- **`DeleteTaskGroup`** usecase で `taskRepository.deleteByTaskGroupId` → `taskGroupRepository.delete` を順に実行。Phase 3-3 で導入した UoW のトランザクション内で実行されるため、原子性は維持。

## 動作不変

外部から見た挙動は変わらない（Task → TaskGroup の順で削除、同一トランザクション内）。アーキテクチャの責務分離だけが整理される。

## Stacked PR

- ベース: `refactor/onion-phase3-3` (#4)
- PR #4 が main にマージされた後、本 PR のベースを `main` に付け替える運用を想定。

## スタック構成

PR #2 (Phase 1+2 DI) → PR #3 (Phase 3-1/3-2/3-5 ドメイン) → PR #4 (Phase 3-3 UoW) → PR #5 (Phase 4 集約境界)

## Test plan

- [ ] `pnpm install` 後 `pnpm --filter @ts-layered-architecture/rest-api exec tsc --noEmit` が通る
- [ ] `pnpm --filter @ts-layered-architecture/rest-api test` が通る
- [ ] 手動: TaskGroup 削除で配下の Task が事前に削除され、TaskGroup も削除される
- [ ] 手動: TaskGroup 削除中に意図的にエラーを起こし、Task と TaskGroup の両方がロールバックされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)