### PR TITLE
chore: パッケージ名を ts-onion-architecture に統一 + CreateUser テスト追加

### DIFF
--- a/apps/nuxt/package.json
+++ b/apps/nuxt/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ts-layered-architecture/nuxt",
+  "name": "@ts-onion-architecture/nuxt",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/rest-api/package.json
+++ b/apps/rest-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ts-layered-architecture/rest-api",
+  "name": "@ts-onion-architecture/rest-api",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/rest-api/tests/application/usecases/CreateUser.test.ts
+++ b/apps/rest-api/tests/application/usecases/CreateUser.test.ts
@@ -1,0 +1,155 @@
+import { IRefreshTokenRepository } from '@/application/repositories/IRefreshTokenRepository';
+import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
+import { ITaskRepository } from '@/application/repositories/ITaskRepository';
+import { IUserRepository } from '@/application/repositories/IUserRepository';
+import { IPasswordHasher } from '@/application/services/IPasswordHasher';
+import { ITokenService } from '@/application/services/ITokenService';
+import { IUnitOfWork, TransactionalRepositories } from '@/application/services/IUnitOfWork';
+import { IUuidGenerator } from '@/application/services/IUuidGenerator';
+import { CreateUser } from '@/application/usecases/auth/CreateUser';
+import { AlreadyExistsError } from '@/domain/errors/AlreadyExistsError';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('usecase', () => {
+  let userRepositoryMock: IUserRepository;
+  let refreshTokenRepositoryMock: IRefreshTokenRepository;
+  let taskRepositoryMock: ITaskRepository;
+  let taskGroupRepositoryMock: ITaskGroupRepository;
+  let unitOfWorkMock: IUnitOfWork;
+  let passwordHasherMock: IPasswordHasher;
+  let tokenServiceMock: ITokenService;
+  let uuidGeneratorMock: IUuidGenerator;
+
+  beforeEach(() => {
+    userRepositoryMock = {
+      findById: vi.fn(),
+      findByEmail: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({
+        id: 1,
+        name: 'test',
+        email: 'test@example.com',
+        hashedPassword: 'HASHED_PASSWORD',
+      }),
+    };
+
+    refreshTokenRepositoryMock = {
+      create: vi.fn(),
+      findByUuid: vi.fn(),
+      delete: vi.fn(),
+      revokeMany: vi.fn(),
+    };
+
+    taskRepositoryMock = {
+      findOne: vi.fn(),
+      findMaxSort: vi.fn(),
+      save: vi.fn(),
+      delete: vi.fn(),
+      deleteDone: vi.fn(),
+      deleteByTaskGroupId: vi.fn(),
+    };
+
+    taskGroupRepositoryMock = {
+      findAll: vi.fn(),
+      findOne: vi.fn(),
+      findMaxSort: vi.fn(),
+      save: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    const repos: TransactionalRepositories = {
+      userRepository: userRepositoryMock,
+      refreshTokenRepository: refreshTokenRepositoryMock,
+      taskRepository: taskRepositoryMock,
+      taskGroupRepository: taskGroupRepositoryMock,
+    };
+
+    unitOfWorkMock = {
+      transaction: vi.fn((work) => work(repos)),
+    };
+
+    passwordHasherMock = {
+      hash: vi.fn().mockResolvedValue('HASHED_PASSWORD'),
+      compare: vi.fn(),
+    };
+
+    tokenServiceMock = {
+      generateTokens: vi.fn().mockReturnValue({
+        accessToken: 'ACCESS_TOKEN',
+        refreshToken: 'REFRESH_TOKEN',
+      }),
+      verifyAccessToken: vi.fn(),
+      verifyRefreshToken: vi.fn(),
+      hashRefreshToken: vi.fn().mockReturnValue('HASHED_REFRESH_TOKEN'),
+    };
+
+    uuidGeneratorMock = {
+      generate: vi.fn().mockReturnValue('UUID-FIXED'),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('CreateUser', () => {
+    it('creates a user and a refresh token within a single transaction and returns tokens', async () => {
+      const usecase = new CreateUser(
+        unitOfWorkMock,
+        passwordHasherMock,
+        tokenServiceMock,
+        uuidGeneratorMock,
+      );
+
+      const result = await usecase.execute({
+        email: 'new@example.com',
+        password: 'password',
+        name: 'new user',
+      });
+
+      expect(result).toEqual({
+        accessToken: 'ACCESS_TOKEN',
+        refreshToken: 'REFRESH_TOKEN',
+      });
+
+      expect(unitOfWorkMock.transaction).toHaveBeenCalledTimes(1);
+      expect(passwordHasherMock.hash).toHaveBeenCalledWith('password');
+      expect(userRepositoryMock.create).toHaveBeenCalledWith({
+        email: 'new@example.com',
+        name: 'new user',
+        hashedPassword: 'HASHED_PASSWORD',
+      });
+      expect(refreshTokenRepositoryMock.create).toHaveBeenCalledWith({
+        uuid: 'UUID-FIXED',
+        hashedToken: 'HASHED_REFRESH_TOKEN',
+        userId: 1,
+      });
+    });
+
+    it('throws AlreadyExistsError when the email is already registered', async () => {
+      userRepositoryMock.findByEmail = vi.fn().mockResolvedValue({
+        id: 1,
+        name: 'existing',
+        email: 'taken@example.com',
+        hashedPassword: 'HASHED_PASSWORD',
+      });
+
+      const usecase = new CreateUser(
+        unitOfWorkMock,
+        passwordHasherMock,
+        tokenServiceMock,
+        uuidGeneratorMock,
+      );
+
+      await expect(
+        usecase.execute({
+          email: 'taken@example.com',
+          password: 'password',
+          name: 'duplicate user',
+        }),
+      ).rejects.toBeInstanceOf(AlreadyExistsError);
+
+      expect(userRepositoryMock.create).not.toHaveBeenCalled();
+      expect(refreshTokenRepositoryMock.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts-layered-architecture",
+  "name": "ts-onion-architecture",
   "private": true,
   "version": "1.0.0",
   "engines": {
@@ -18,8 +18,8 @@
     "typescript": "^5.3.3"
   },
   "scripts": {
-    "@rest": "pnpm -F @ts-layered-architecture/rest-api",
-    "@nuxt": "pnpm -F @ts-layered-architecture/nuxt",
+    "@rest": "pnpm -F @ts-onion-architecture/rest-api",
+    "@nuxt": "pnpm -F @ts-onion-architecture/nuxt",
     "dev": "turbo dev",
     "build": "turbo build",
     "format": "turbo format",


### PR DESCRIPTION
## Summary

Phase 5: 軽微なクリーンアップ。

### パッケージ名の統一

リポジトリ／ディレクトリは `ts-onion-architecture` だが、`package.json` の名前はまだ旧名 `ts-layered-architecture` のままだった。実体（オニオン）と一致させる。

- ルート \`package.json\` の \`name\` と \`scripts.@rest\` / \`scripts.@nuxt\` の pnpm filter
- \`apps/nuxt/package.json\` の \`name\`
- \`apps/rest-api/package.json\` の \`name\`

ワークスペース内のクロス参照は無く、`pnpm-lock.yaml` にも旧名の参照は無い（確認済み）ため lockfile 更新は不要。

### CreateUser の単体テスト追加

Phase 3-3 で UoW を導入した `CreateUser` に対する単体テストを追加：

- **正常系**: `user.create` と `refreshToken.create` が同一 transaction 内で呼ばれ、トークン対が返る
- **異常系**: メール重複で `AlreadyExistsError` を投げ、`create` 系は呼ばれない

`SignIn.test.ts` のスタイルに合わせて vitest ベースで実装。`IUnitOfWork.transaction` は `(work) => work(repos)` でモックし、UoW の境界を意識したテストになっている。

## Test plan

- [ ] \`pnpm install\` 後 \`pnpm --filter @ts-onion-architecture/rest-api test\` が両テスト緑
- [ ] \`pnpm @rest test\` と \`pnpm @nuxt dev\` が新パッケージ名でも動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)