### PR TITLE
refactor(rest-api): 読み取り側でも集約境界を尊重

### DIFF
--- a/apps/rest-api/src/application/repositories/ITaskRepository.ts
+++ b/apps/rest-api/src/application/repositories/ITaskRepository.ts
@@ -2,6 +2,7 @@ import { TaskModel } from '@/domain/models/TaskModel';
 
 export interface ITaskRepository {
   findOne(params: { id: number; userId: number }): Promise<TaskModel | null>;
+  findAllByTaskGroupId(params: { taskGroupId: number }): Promise<TaskModel[]>;
   findMaxSort(params: { userId: number; taskGroupId: number }): Promise<number>;
   save(params: { item: TaskModel }): Promise<TaskModel>;
   delete(params: { item: TaskModel }): Promise<number>;

--- a/apps/rest-api/src/application/usecases/taskGroup/GetTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/GetTaskGroup.ts
@@ -1,12 +1,28 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
+import { ITaskRepository } from '@/application/repositories/ITaskRepository';
+import { TaskGroupModel } from '@/domain/models/TaskGroupModel';
+import { TaskModel } from '@/domain/models/TaskModel';
+
+export type GetTaskGroupResult = {
+  taskGroup: TaskGroupModel;
+  tasks: TaskModel[];
+};
 
 export class GetTaskGroup {
-  constructor(private repository: ITaskGroupRepository) {}
+  constructor(
+    private taskGroupRepository: ITaskGroupRepository,
+    private taskRepository: ITaskRepository,
+  ) {}
 
-  async execute(params: { id: number; userId: number }) {
-    return await this.repository.findOne({
+  async execute(params: { id: number; userId: number }): Promise<GetTaskGroupResult | null> {
+    const taskGroup = await this.taskGroupRepository.findOne({
       id: params.id,
       userId: params.userId,
     });
+    if (!taskGroup) return null;
+
+    const tasks = await this.taskRepository.findAllByTaskGroupId({ taskGroupId: taskGroup.id });
+
+    return { taskGroup, tasks };
   }
 }

--- a/apps/rest-api/src/domain/models/TaskGroupModel.ts
+++ b/apps/rest-api/src/domain/models/TaskGroupModel.ts
@@ -1,11 +1,9 @@
 import { BaseModel } from './BaseModel';
-import { TaskModel } from './TaskModel';
 
 export class TaskGroupModel extends BaseModel {
   readonly userId: number;
   readonly name: string;
   readonly sort: number;
-  readonly tasks?: TaskModel[];
 
   static readonly INITIAL_SORT_VALUE = 65535;
 
@@ -14,13 +12,11 @@ export class TaskGroupModel extends BaseModel {
     userId: number;
     name: string;
     sort: number;
-    tasks?: TaskModel[];
   }) {
     super({ id: props.id });
     this.userId = props.userId;
     this.name = props.name;
     this.sort = props.sort;
-    this.tasks = props.tasks;
   }
 
   static createNew(props: {
@@ -53,7 +49,6 @@ export class TaskGroupModel extends BaseModel {
       userId: this.userId,
       name: updates.name ?? this.name,
       sort: updates.sort ?? this.sort,
-      tasks: this.tasks,
     });
   }
 }

--- a/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
@@ -1,6 +1,5 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
 import { TaskGroupModel } from '@/domain/models/TaskGroupModel';
-import { TaskModel } from '@/domain/models/TaskModel';
 import { Prisma } from '@prisma/client';
 
 export class TaskGroupRepository implements ITaskGroupRepository {
@@ -43,36 +42,12 @@ export class TaskGroupRepository implements ITaskGroupRepository {
 
     if (!item) return null;
 
-    const tasks = await this.db.task.findMany({
-      where: {
-        taskGroupId: item.id,
-      },
-      orderBy: {
-        sort: 'asc',
-      },
-    });
-
-    const model = new TaskGroupModel({
+    return new TaskGroupModel({
       id: item.id,
       userId: item.userId,
       name: item.name,
       sort: item.sort,
-      tasks: tasks.map(
-        (task) =>
-          new TaskModel({
-            id: task.id,
-            taskGroupId: task.taskGroupId,
-            title: task.title,
-            description: task.description ?? undefined,
-            dueDate: task.dueDate ?? undefined,
-            dueTime: task.dueTime ?? undefined,
-            done: task.done,
-            sort: task.sort,
-          }),
-      ),
     });
-
-    return model;
   }
 
   async findMaxSort(params: { userId: number }): Promise<number> {

--- a/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
@@ -24,6 +24,26 @@ export class TaskRepository implements ITaskRepository {
     return model;
   }
 
+  async findAllByTaskGroupId(params: { taskGroupId: number }): Promise<TaskModel[]> {
+    const list = await this.db.task.findMany({
+      where: { taskGroupId: params.taskGroupId },
+      orderBy: { sort: 'asc' },
+    });
+    return list.map(
+      (item) =>
+        new TaskModel({
+          id: item.id,
+          taskGroupId: item.taskGroupId,
+          title: item.title,
+          description: item.description ?? undefined,
+          dueDate: item.dueDate ?? undefined,
+          dueTime: item.dueTime ?? undefined,
+          done: item.done,
+          sort: item.sort,
+        }),
+    );
+  }
+
   async findMaxSort(params: { userId: number; taskGroupId: number }): Promise<number> {
     const item = await this.db.task.findFirst({
       select: { sort: true },

--- a/apps/rest-api/src/interfaces/controllers/TaskGroupController.ts
+++ b/apps/rest-api/src/interfaces/controllers/TaskGroupController.ts
@@ -13,7 +13,7 @@ export class TaskGroupController {
     id: number;
     userId: number;
   }) {
-    const usecase = new GetTaskGroup(this.deps.taskGroupRepository);
+    const usecase = new GetTaskGroup(this.deps.taskGroupRepository, this.deps.taskRepository);
     const item = await usecase.execute({
       id: params.id,
       userId: params.userId,

--- a/apps/rest-api/src/interfaces/http/routes/taskGroups/getTaskGroup.ts
+++ b/apps/rest-api/src/interfaces/http/routes/taskGroups/getTaskGroup.ts
@@ -29,7 +29,7 @@ export const createGetTaskGroup = (deps: AppDeps) =>
 
     return successResponse(
       JSON.stringify({
-        item: res,
+        item: { ...res.taskGroup, tasks: res.tasks },
       }),
     );
   });


### PR DESCRIPTION
## Summary

Phase 4 で「Task は独立集約」と扱って書き込み側のカスケードを usecase に移したが、読み取り側は `TaskGroupRepository.findOne` が子 Task を bundle ロードし、`TaskGroupModel` に `tasks?: TaskModel[]` を抱えていた。書き手と読み手の方針が分裂していたのを、読み手も集約境界を越えないように整える。

## 変更点

- **`TaskGroupModel`** から `tasks?: TaskModel[]` を削除。純粋な集約ルートに。
- **`TaskGroupRepository.findOne`** から `db.task.findMany` を除去。`TaskGroupRepository` は他集約のテーブルを触らなくなった。
- **`ITaskRepository.findAllByTaskGroupId`** を追加（純粋な Task 集約フェッチ）。
- **`GetTaskGroup`** は両集約を順に取得し `{ taskGroup, tasks }` を返す合成 usecase に変更。
- **route** で `{ ...taskGroup, tasks }` に展開するため、外部から見た JSON レスポンス形状は不変。

## アーキテクチャ的に解消されたこと

| 観点 | Before | After |
| --- | --- | --- |
| 集約越境（書） | Phase 4 で解消済み | 維持 |
| 集約越境（読） | `TaskGroupRepository` が `db.task` を直接参照 | usecase で合成 |
| ドメインモデル | `TaskGroupModel` に他集約 `TaskModel[]` の参照 | 純粋な集約ルート |

## Test plan

- [ ] `pnpm install` 後 `pnpm --filter @ts-onion-architecture/rest-api exec tsc --noEmit` が通る
- [ ] `pnpm --filter @ts-onion-architecture/rest-api test` が通る
- [ ] 手動: `GET /task-groups/:id` のレスポンス形状が以前と同じ（`{ item: { id, userId, name, sort, tasks: [...] } }`）
- [ ] 手動: 存在しない id で 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)