### PR TITLE
refactor(rest-api): tactical DDD — Sort VO and intention-revealing model methods

### DIFF
--- a/apps/rest-api/src/application/usecases/task/CreateTask.ts
+++ b/apps/rest-api/src/application/usecases/task/CreateTask.ts
@@ -23,7 +23,7 @@ export class CreateTask {
       description: params.description,
       dueDate: params.dueDate,
       dueTime: params.dueTime,
-      maxSort,
+      afterMaxSort: maxSort,
     });
     return await this.repository.save({ item: model });
   }

--- a/apps/rest-api/src/application/usecases/task/UpdateTask.ts
+++ b/apps/rest-api/src/application/usecases/task/UpdateTask.ts
@@ -12,7 +12,6 @@ export class UpdateTask {
     dueDate?: string;
     dueTime?: string;
     done?: boolean;
-    sort?: number;
   }) {
     const model = await this.repository.findOne({
       id: params.taskId,
@@ -22,14 +21,15 @@ export class UpdateTask {
       throw new NotFoundError('Task not found');
     }
 
-    const updated = model.withUpdates({
+    let updated = model.changeContent({
       title: params.title,
       description: params.description,
       dueDate: params.dueDate,
       dueTime: params.dueTime,
-      done: params.done,
-      sort: params.sort,
     });
+    if (params.done !== undefined) {
+      updated = updated.markDone(params.done);
+    }
 
     return await this.repository.save({ item: updated });
   }

--- a/apps/rest-api/src/application/usecases/task/UpdateTaskSort.ts
+++ b/apps/rest-api/src/application/usecases/task/UpdateTaskSort.ts
@@ -1,6 +1,5 @@
 import { ITaskRepository } from '@/application/repositories/ITaskRepository';
 import { NotFoundError } from '@/domain/errors/NotFoundError';
-import { TaskModel } from '@/domain/models/TaskModel';
 
 export class UpdateTaskSort {
   constructor(private repository: ITaskRepository) {}
@@ -19,7 +18,7 @@ export class UpdateTaskSort {
       throw new NotFoundError('Task not found');
     }
 
-    let prevSort: number | null = null;
+    let prev = null;
     if (params.prevId) {
       const prevModel = await this.repository.findOne({
         id: params.prevId,
@@ -28,10 +27,10 @@ export class UpdateTaskSort {
       if (!prevModel) {
         throw new NotFoundError('Task not found');
       }
-      prevSort = prevModel.sort;
+      prev = prevModel.sort;
     }
 
-    let nextSort: number | null = null;
+    let next = null;
     if (params.nextId) {
       const nextModel = await this.repository.findOne({
         id: params.nextId,
@@ -40,12 +39,10 @@ export class UpdateTaskSort {
       if (!nextModel) {
         throw new NotFoundError('Task not found');
       }
-      nextSort = nextModel.sort;
+      next = nextModel.sort;
     }
 
-    const updated = model.withUpdates({
-      sort: TaskModel.sortBetween(prevSort, nextSort),
-    });
+    const updated = model.reorderBetween(prev, next);
 
     return await this.repository.save({ item: updated });
   }

--- a/apps/rest-api/src/application/usecases/taskGroup/CreateTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/CreateTaskGroup.ts
@@ -10,7 +10,7 @@ export class CreateTaskGroup {
     const model = TaskGroupModel.createNew({
       userId: params.userId,
       name: params.name,
-      maxSort,
+      afterMaxSort: maxSort,
     });
     return await this.repository.save({ item: model });
   }

--- a/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroup.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroup.ts
@@ -4,12 +4,7 @@ import { NotFoundError } from '@/domain/errors/NotFoundError';
 export class UpdateTaskGroup {
   constructor(private repository: ITaskGroupRepository) {}
 
-  async execute(params: {
-    userId: number;
-    taskGroupId: number;
-    name?: string;
-    sort?: number;
-  }) {
+  async execute(params: { userId: number; taskGroupId: number; name: string }) {
     const model = await this.repository.findOne({
       id: params.taskGroupId,
       userId: params.userId,
@@ -18,10 +13,7 @@ export class UpdateTaskGroup {
       throw new NotFoundError('TaskGroup not found');
     }
 
-    const updated = model.withUpdates({
-      name: params.name,
-      sort: params.sort,
-    });
+    const updated = model.rename(params.name);
 
     return await this.repository.save({ item: updated });
   }

--- a/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroupSort.ts
+++ b/apps/rest-api/src/application/usecases/taskGroup/UpdateTaskGroupSort.ts
@@ -1,6 +1,5 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
 import { NotFoundError } from '@/domain/errors/NotFoundError';
-import { TaskGroupModel } from '@/domain/models/TaskGroupModel';
 
 export class UpdateTaskGroupSort {
   constructor(private repository: ITaskGroupRepository) {}
@@ -19,7 +18,7 @@ export class UpdateTaskGroupSort {
       throw new NotFoundError('TaskGroup not found');
     }
 
-    let prevSort: number | null = null;
+    let prev = null;
     if (params.prevId) {
       const prevModel = await this.repository.findOne({
         id: params.prevId,
@@ -28,10 +27,10 @@ export class UpdateTaskGroupSort {
       if (!prevModel) {
         throw new NotFoundError('TaskGroup not found');
       }
-      prevSort = prevModel.sort;
+      prev = prevModel.sort;
     }
 
-    let nextSort: number | null = null;
+    let next = null;
     if (params.nextId) {
       const nextModel = await this.repository.findOne({
         id: params.nextId,
@@ -40,12 +39,10 @@ export class UpdateTaskGroupSort {
       if (!nextModel) {
         throw new NotFoundError('TaskGroup not found');
       }
-      nextSort = nextModel.sort;
+      next = nextModel.sort;
     }
 
-    const updated = model.withUpdates({
-      sort: TaskGroupModel.sortBetween(prevSort, nextSort),
-    });
+    const updated = model.reorderBetween(prev, next);
 
     return await this.repository.save({ item: updated });
   }

--- a/apps/rest-api/src/domain/models/TaskGroupModel.ts
+++ b/apps/rest-api/src/domain/models/TaskGroupModel.ts
@@ -1,17 +1,16 @@
+import { Sort } from '@/domain/values/Sort';
 import { BaseModel } from './BaseModel';
 
 export class TaskGroupModel extends BaseModel {
   readonly userId: number;
   readonly name: string;
-  readonly sort: number;
-
-  static readonly INITIAL_SORT_VALUE = 65535;
+  readonly sort: Sort;
 
   constructor(props: {
     id: number;
     userId: number;
     name: string;
-    sort: number;
+    sort: Sort;
   }) {
     super({ id: props.id });
     this.userId = props.userId;
@@ -22,33 +21,32 @@ export class TaskGroupModel extends BaseModel {
   static createNew(props: {
     userId: number;
     name: string;
-    maxSort: number;
+    afterMaxSort: number;
   }): TaskGroupModel {
     return new TaskGroupModel({
       id: 0,
       userId: props.userId,
       name: props.name,
-      sort: Math.floor(props.maxSort) + TaskGroupModel.INITIAL_SORT_VALUE,
+      sort: Sort.appendAfter(props.afterMaxSort),
     });
   }
 
-  static sortBetween(prev: number | null, next: number | null): number {
-    const prevSort = prev ?? 0;
-    const nextSort = next ?? TaskGroupModel.INITIAL_SORT_VALUE;
-    return (prevSort + nextSort) / 2;
-  }
-
-  withUpdates(
-    updates: Partial<{
-      name: string;
-      sort: number;
-    }>,
-  ): TaskGroupModel {
+  rename(name: string): TaskGroupModel {
+    if (this.name === name) return this;
     return new TaskGroupModel({
       id: this.id,
       userId: this.userId,
-      name: updates.name ?? this.name,
-      sort: updates.sort ?? this.sort,
+      name,
+      sort: this.sort,
+    });
+  }
+
+  reorderBetween(prev: Sort | null, next: Sort | null): TaskGroupModel {
+    return new TaskGroupModel({
+      id: this.id,
+      userId: this.userId,
+      name: this.name,
+      sort: Sort.between(prev, next),
     });
   }
 }

--- a/apps/rest-api/src/domain/models/TaskModel.ts
+++ b/apps/rest-api/src/domain/models/TaskModel.ts
@@ -1,15 +1,14 @@
+import { Sort } from '@/domain/values/Sort';
 import { BaseModel } from './BaseModel';
 
 export class TaskModel extends BaseModel {
   readonly taskGroupId: number;
   readonly title: string;
-  readonly done?: boolean;
+  readonly done: boolean;
   readonly description?: string;
   readonly dueDate?: string;
   readonly dueTime?: string;
-  readonly sort: number;
-
-  static readonly INITIAL_SORT_VALUE = 65535;
+  readonly sort: Sort;
 
   constructor(props: {
     id: number;
@@ -19,12 +18,12 @@ export class TaskModel extends BaseModel {
     description?: string;
     dueDate?: string;
     dueTime?: string;
-    sort: number;
+    sort: Sort;
   }) {
     super({ id: props.id });
     this.taskGroupId = props.taskGroupId;
     this.title = props.title;
-    this.done = props.done;
+    this.done = props.done ?? false;
     this.description = props.description;
     this.dueDate = props.dueDate;
     this.dueTime = props.dueTime;
@@ -37,7 +36,7 @@ export class TaskModel extends BaseModel {
     description?: string;
     dueDate?: string;
     dueTime?: string;
-    maxSort: number;
+    afterMaxSort: number;
   }): TaskModel {
     return new TaskModel({
       id: 0,
@@ -46,24 +45,16 @@ export class TaskModel extends BaseModel {
       description: props.description,
       dueDate: props.dueDate,
       dueTime: props.dueTime,
-      sort: Math.floor(props.maxSort) + TaskModel.INITIAL_SORT_VALUE,
+      sort: Sort.appendAfter(props.afterMaxSort),
     });
   }
 
-  static sortBetween(prev: number | null, next: number | null): number {
-    const prevSort = prev ?? 0;
-    const nextSort = next ?? TaskModel.INITIAL_SORT_VALUE;
-    return (prevSort + nextSort) / 2;
-  }
-
-  withUpdates(
+  changeContent(
     updates: Partial<{
       title: string;
       description: string;
       dueDate: string;
       dueTime: string;
-      done: boolean;
-      sort: number;
     }>,
   ): TaskModel {
     return new TaskModel({
@@ -73,8 +64,35 @@ export class TaskModel extends BaseModel {
       description: updates.description ?? this.description,
       dueDate: updates.dueDate ?? this.dueDate,
       dueTime: updates.dueTime ?? this.dueTime,
-      done: updates.done ?? this.done,
-      sort: updates.sort ?? this.sort,
+      done: this.done,
+      sort: this.sort,
+    });
+  }
+
+  markDone(done: boolean): TaskModel {
+    if (this.done === done) return this;
+    return new TaskModel({
+      id: this.id,
+      taskGroupId: this.taskGroupId,
+      title: this.title,
+      description: this.description,
+      dueDate: this.dueDate,
+      dueTime: this.dueTime,
+      done,
+      sort: this.sort,
+    });
+  }
+
+  reorderBetween(prev: Sort | null, next: Sort | null): TaskModel {
+    return new TaskModel({
+      id: this.id,
+      taskGroupId: this.taskGroupId,
+      title: this.title,
+      description: this.description,
+      dueDate: this.dueDate,
+      dueTime: this.dueTime,
+      done: this.done,
+      sort: Sort.between(prev, next),
     });
   }
 }

--- a/apps/rest-api/src/domain/values/Sort.ts
+++ b/apps/rest-api/src/domain/values/Sort.ts
@@ -1,0 +1,23 @@
+export class Sort {
+  static readonly INITIAL_GAP = 65535;
+
+  private constructor(readonly value: number) {}
+
+  static of(value: number): Sort {
+    return new Sort(value);
+  }
+
+  static appendAfter(maxSort: number): Sort {
+    return new Sort(Math.floor(maxSort) + Sort.INITIAL_GAP);
+  }
+
+  static between(prev: Sort | null, next: Sort | null): Sort {
+    const prevValue = prev?.value ?? 0;
+    const nextValue = next?.value ?? Sort.INITIAL_GAP;
+    return new Sort((prevValue + nextValue) / 2);
+  }
+
+  toJSON(): number {
+    return this.value;
+  }
+}

--- a/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskGroupRepository.ts
@@ -1,5 +1,6 @@
 import { ITaskGroupRepository } from '@/application/repositories/ITaskGroupRepository';
 import { TaskGroupModel } from '@/domain/models/TaskGroupModel';
+import { Sort } from '@/domain/values/Sort';
 import { Prisma } from '@prisma/client';
 
 export class TaskGroupRepository implements ITaskGroupRepository {
@@ -26,7 +27,7 @@ export class TaskGroupRepository implements ITaskGroupRepository {
           id: item.id,
           userId: item.userId,
           name: item.name,
-          sort: item.sort,
+          sort: Sort.of(item.sort),
         }),
     );
     return models;
@@ -46,7 +47,7 @@ export class TaskGroupRepository implements ITaskGroupRepository {
       id: item.id,
       userId: item.userId,
       name: item.name,
-      sort: item.sort,
+      sort: Sort.of(item.sort),
     });
   }
 
@@ -70,7 +71,7 @@ export class TaskGroupRepository implements ITaskGroupRepository {
         where: { id: item.id },
         data: {
           name: item.name,
-          sort: item.sort,
+          sort: item.sort.value,
         },
       });
       return item;
@@ -79,14 +80,14 @@ export class TaskGroupRepository implements ITaskGroupRepository {
       data: {
         userId: item.userId,
         name: item.name,
-        sort: item.sort,
+        sort: item.sort.value,
       },
     });
     return new TaskGroupModel({
       id: res.id,
       userId: res.userId,
       name: res.name,
-      sort: res.sort,
+      sort: Sort.of(res.sort),
     });
   }
 

--- a/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
+++ b/apps/rest-api/src/infrastructure/repository/TaskRepository.ts
@@ -1,5 +1,6 @@
 import { ITaskRepository } from '@/application/repositories/ITaskRepository';
 import { TaskModel } from '@/domain/models/TaskModel';
+import { Sort } from '@/domain/values/Sort';
 import { Prisma } from '@prisma/client';
 
 export class TaskRepository implements ITaskRepository {
@@ -19,7 +20,7 @@ export class TaskRepository implements ITaskRepository {
       dueDate: item.dueDate ?? undefined,
       dueTime: item.dueTime ?? undefined,
       done: item.done,
-      sort: item.sort,
+      sort: Sort.of(item.sort),
     });
     return model;
   }
@@ -39,7 +40,7 @@ export class TaskRepository implements ITaskRepository {
           dueDate: item.dueDate ?? undefined,
           dueTime: item.dueTime ?? undefined,
           done: item.done,
-          sort: item.sort,
+          sort: Sort.of(item.sort),
         }),
     );
   }
@@ -67,7 +68,7 @@ export class TaskRepository implements ITaskRepository {
           dueDate: item.dueDate,
           dueTime: item.dueTime,
           done: item.done,
-          sort: item.sort,
+          sort: item.sort.value,
         },
       });
       return item;
@@ -82,7 +83,7 @@ export class TaskRepository implements ITaskRepository {
         dueDate: item.dueDate,
         dueTime: item.dueTime,
         done: item.done,
-        sort: item.sort,
+        sort: item.sort.value,
       },
     });
     const newItem = new TaskModel({
@@ -93,7 +94,7 @@ export class TaskRepository implements ITaskRepository {
       dueDate: res.dueDate ?? undefined,
       dueTime: res.dueTime ?? undefined,
       done: res.done,
-      sort: res.sort,
+      sort: Sort.of(res.sort),
     });
     return newItem;
   }

--- a/apps/rest-api/tests/application/usecases/CreateUser.test.ts
+++ b/apps/rest-api/tests/application/usecases/CreateUser.test.ts
@@ -41,6 +41,7 @@ describe('usecase', () => {
 
     taskRepositoryMock = {
       findOne: vi.fn(),
+      findAllByTaskGroupId: vi.fn(),
       findMaxSort: vi.fn(),
       save: vi.fn(),
       delete: vi.fn(),


### PR DESCRIPTION
## Summary
- `domain/values/Sort.ts` を新設し、`TaskModel` / `TaskGroupModel` に重複していた `sortBetween` / `INITIAL_SORT_VALUE` を一箇所に集約。`toJSON()` を実装しているので API レスポンスの shape は変わりません。
- `withUpdates({...})` という汎用セッターを廃止し、意図のあるメソッド (`TaskModel.changeContent` / `markDone` / `reorderBetween`、`TaskGroupModel.rename` / `reorderBetween`) に分割。これにより \"sort: 0 を渡すと既存値を破壊する\" 類の事故を構造的に防げます。
- `UpdateTask` を content 更新と done 切替の二段階に分け、`UpdateTaskGroup` は `rename` のみ扱う形に整理。
- リポジトリ実装は永続化境界で `Sort.of(value)` ↔ `sort.value` の変換を行い、ドメイン側からは Sort 型を保つ。
- 既存テスト (`CreateUser.test.ts`) の mock が Phase6 で追加された `findAllByTaskGroupId` に追従していなかったため、別コミットで補正。

## スコープ外（Phase8 候補）
- TaskGroup を集約 root として書き込み側にも境界を効かせる（Task の作成/更新/削除を root 経由に集約）整理。今回は変更が大きくなるため見送り。

## Test plan
- [x] \`pnpm --filter @ts-onion-architecture/rest-api test\` 相当のテスト 3 本が pass
- [ ] 動作確認: TaskGroup / Task の create / update (content / done) / sort / delete / done sweep が API から期待通り動く
- [ ] レスポンス JSON で \`sort\` が引き続き number として出ていること（toJSON 経由）

🤖 Generated with [Claude Code](https://claude.com/claude-code)